### PR TITLE
Fix unmount failure for paths with symlinks

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,2 @@
+type: 'generic'
+reviewers: 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ fn main() {
     let root_mountpoint = Path::new("/").join(&t.as_str());
     if !root_mountpoint.exists() {
         println!(
-            "ERROR: {} doesn't exist. Nothing to mount.",
+            "ERROR: Mountpoint {} doesn't exist.",
             root_mountpoint.display()
         );
         exit(1);
@@ -232,18 +232,22 @@ fn main() {
     match c {
         Command::Mount => {
             println!(
-                "INFO: Bindmounting {} in {} ...",
-                root_mountpoint.display(),
-                bind_mountpoint.display()
+                "INFO: Bindmounting {} on {} ...",
+                bind_mountpoint.display(),
+                root_mountpoint.display()
             );
 
             if is_mounted {
-                println!("INFO: bind mountpont is already mounted.");
+                println!("INFO: Bind mountpoint is already mounted.");
                 exit(0);
             }
         }
         Command::Umount => {
-            println!("INFO: Unmounting {} ...", bind_mountpoint.display());
+            println!(
+                "INFO: Unmounting {} from {} ...",
+                bind_mountpoint.display(),
+                root_mountpoint.display()
+            );
 
             if is_mounted {
                 unsafe {
@@ -253,19 +257,19 @@ fn main() {
                             .as_ptr(),
                     );
                     if ret == 0 {
-                        println!("INFO: Successfully unmounted {}.", bind_mountpoint.display());
+                        println!("INFO: Successfully unmounted {}.", root_mountpoint.display());
                         exit(0);
                     } else {
                         println!(
                             "ERROR: Failed to unmount {}: {}.",
-                            bind_mountpoint.display(),
+                            root_mountpoint.display(),
                             errno::errno()
                         );
                         exit(1);
                     }
                 }
             } else {
-                println!("INFO: bind mountpont is already unmounted.");
+                println!("INFO: Bind mountpoint is already unmounted.");
                 exit(0);
             }
         }
@@ -304,11 +308,11 @@ fn main() {
             0 as *mut libc::c_void,
         );
         if ret == 0 {
-            println!("INFO: Successfully mounted {}.", bind_mountpoint.display());
+            println!("INFO: Successfully mounted {}.", root_mountpoint.display());
         } else {
             println!(
                 "ERROR: Failed to mount {}: {}.",
-                bind_mountpoint.display(),
+                root_mountpoint.display(),
                 errno::errno()
             );
             exit(1);


### PR DESCRIPTION
Root mountpoint directories that contain a symbolic link are not handled correctly.

For example, /var/log/ -> /var/volatile/log, in this case when we mount something to /var/log/... the kernel records the mountpoint as /var/volatile/log/..., so when we try to unmount /var/log/... it fails.

This problem is fixed by fully expanding the mountpoint path (with canonicalize) before checking and unmounting the mountpoint.

Also make some improvements to the log messages and fix some typos.